### PR TITLE
Remove gcc-4.8 dependency in Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,10 +1,10 @@
 TARGET = paralelo
 TARGET_DBG = paralelo_dbg
 
-CC = gcc-4.8
+CC = gcc
 NVCC = nvcc
 
-CFLAGS = -Wall -O3 -std=c++11 
+CFLAGS = -Wall -O3 -std=c++11 -D_MWAITXINTRIN_H_INCLUDED
 SRC = $(wildcard *.cu)
 OBJ = ${SRC:.cu=.o}
 OBJ_DBG = ${SRC:.cu=_dbg.o}


### PR DESCRIPTION
-> add -D_MWAITXINTRIN_H_INCLUDED directive to solve compilation errors
with new gcc versions and algoritm.h
